### PR TITLE
feat/navigator : 이전/다음페이지로 이동할 수 있는 navigator를 함께 그려준다

### DIFF
--- a/src/scripts/carousel.js
+++ b/src/scripts/carousel.js
@@ -1,5 +1,6 @@
 import "../styles/style.scss";
 import { PROJECTOR_CLASS, CONTAINER_CLASS, DEFAULT_OPTIONS, ERROR_MESSAGE } from "./config";
+import Navigator from "./navigator";
 
 export default class SlideProjector {
   constructor(option){
@@ -33,13 +34,23 @@ export default class SlideProjector {
 
   _wrapInContainer(){
     const slideContainer = this._generateSlideContainer();
-    this._setSlideWidth(slideContainer);
     this._fillProjectorWith(slideContainer);
+    this._setSlideWidth(slideContainer);
+  }
+
+  _setNavigator(slideContainer){
+    const nav = new Navigator(slideContainer, this.slideCount, this.projectorWidth);
+    this.projector.appendChild(nav.prevButton);
+    this.projector.appendChild(nav.nextButton);
+    nav.bindEvents();
   }
 
   _fillProjectorWith(slideContainer){
     this.projector.innerHTML = "";
     this.projector.appendChild(slideContainer);
+    if(this.option.nav.show){
+      this._setNavigator(slideContainer);
+    }
   }
 
   _generateSlideContainer(){

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -1,10 +1,18 @@
 export const VERSION = 1.0;
 export const PROJECTOR_CLASS = "slide-projector";
 export const CONTAINER_CLASS = "slider-projector-container";
+export const NAV_CLASS = {
+  PREV_BUTTON: "sp-navigator sp-navigator__prev",
+  NEXT_BUTTON: "sp-navigator sp-navigator__next"
+};
 
 export const DEFAULT_OPTIONS = {
   width: 400,
-  height: 300
+  height: 300,
+  nav: {
+    style: "arrow",
+    show: true
+  }
 };
 
 export const ERROR_MESSAGE = {

--- a/src/scripts/navigator.js
+++ b/src/scripts/navigator.js
@@ -1,0 +1,53 @@
+import { NAV_CLASS } from "./config";
+
+export default class Navigator {
+  constructor(slideContainer, slideCount, slideWidth){
+    this.container = slideContainer;
+    this.slideWidth = slideWidth;
+    this.slideCount = slideCount;
+    this.currentSlideId = 0;
+    this.prevButton = this._generatePrevButton();
+    this.nextButton = this._generateNextButton();
+  }
+  
+  bindEvents(){
+    this.prevButton.addEventListener("click", this._slidePrev.bind(this));
+    this.nextButton.addEventListener("click", this._slideNext.bind(this));
+  }
+  
+  _slidePrev(){
+    if(this.currentSlideId === 0){
+      return;
+    }
+    const targetSlideId = this.currentSlideId - 1;
+    const currentPosition = this.slideWidth * this.currentSlideId;
+    const targetPosition = -currentPosition + this.slideWidth;
+    this.currentSlideId = targetSlideId;
+    this.container.style.transform = `translateX(${targetPosition}px)`;
+  }
+  
+  _slideNext(){
+    if(this.currentSlideId === (this.slideCount-1)){
+      return;
+    }
+    const targetSlideId = this.currentSlideId + 1;
+    const currentPosition = this.slideWidth * this.currentSlideId;
+    const targetPosition = -currentPosition - this.slideWidth;
+    this.currentSlideId = targetSlideId;
+    this.container.style.transform = `translateX(${targetPosition}px)`;
+  }
+  
+  _generatePrevButton(){
+    const prevButton = document.createElement("button");
+    prevButton.innerHTML = "&#8249;";
+    prevButton.className = NAV_CLASS.PREV_BUTTON;
+    return prevButton;
+  }
+  
+  _generateNextButton(){
+    const nextButton = document.createElement("button");
+    nextButton.innerHTML = "&#8250;";
+    nextButton.className = NAV_CLASS.NEXT_BUTTON;
+    return nextButton;
+  }
+}

--- a/src/styles/navigator.scss
+++ b/src/styles/navigator.scss
@@ -1,0 +1,27 @@
+.slide-projector{
+  .sp-navigator{
+    position: absolute;
+    margin: auto;
+    top: 0;
+    bottom: 0;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    font-size: 30px;
+    background: transparent;
+    cursor: pointer;
+    outline: none;
+    
+    &:hover{
+      color: #fff;
+    }
+    
+    &__prev{
+      left: 0;
+    }
+
+    &__next{
+      right: 0;
+    }  
+  }  
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,4 +1,5 @@
 @import "reset";
+@import "navigator";
 $default-color: rgb(122,201,188);
 $first-color: rgb(223,229,229);
 $second-color: rgb(236,220,191);
@@ -12,6 +13,10 @@ $fifth-color: rgb(123,168,83);
     overflow: hidden;
   }
   .slider-projector-container {
+    &{
+      position: relative;
+      transition: transform .5s;
+    }
     div {
         & {
           height: 100%;


### PR DESCRIPTION
> (왜 벌써부터 컨플릭트죠?! ㅠ_____ㅜ)
#### 구현사항
- navigator 모듈을 따로 분리하였습니다. 
- 초기화할 때 container를 만들어서 갈아끼우는 시점에, navigator도 붙여줍니다. 
- 다음의 기본 동작만 구현된 상태입니다.
  - navigator를 클릭하여 이전/다음 페이지로 이동할 수 있다.
  - 첫 페이지에서 이전 페이지 버튼을 클릭하면 이동하지 않는다.
  - 마지막 페이지에서 다음 페이지 버튼을 클릭하면 이동하지 않는다.

#### 고민거리 
- pagination이랑 연동을 어찌 잘 시켜야 할 것 같은 느낌이네요 
- 이런 경우 구조화는 어떤 식으로 해야하는 걸까요..?_? -> 이런 포인트가 디자인 패턴이 등장하는 것이려나요?!